### PR TITLE
Update URLs to import views instead of using strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,30 @@
+sudo: false
+
 language: python
 
-# Test with both Python 2.7 and 3.4
 python:
   - "2.7"
+  - "3.3"
   - "3.4"
+  - "3.5"
+  - "pypy"
+  - "pypy3"
+
+env:
+  - DJANGO="Django<1.8"
+  - DJANGO="Django<1.9"
+  - DJANGO="Django<1.10"
+
+matrix:
+  exclude:
+    - env: DJANGO="Django<1.10"
+      python: "3.3"
+
 
 # Install dependencies.
-install: "pip install -r requirements.txt"
+install: 
+  - pip install -q $DJANGO
+  - pip install -r requirements.txt
 
 # Run tests.
-script: 'python test.py'
+script: python test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 
 
 # Install dependencies.
-install: 
+install:
   - pip install -q $DJANGO
   - pip install -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
 
 matrix:
   exclude:
+    - env: DJANGO="Django<1.8"
+      python: "3.5"
     - env: DJANGO="Django<1.10"
       python: "3.3"
     - env: DJANGO="Django<1.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
   exclude:
     - env: DJANGO="Django<1.10"
       python: "3.3"
+    - env: DJANGO="Django<1.10"
+      python: "pypy3"
 
 
 # Install dependencies.

--- a/shopify_auth/urls.py
+++ b/shopify_auth/urls.py
@@ -1,7 +1,9 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns('',
-  url(r'^finalize/$',     'shopify_auth.views.finalize'),
-  url(r'^authenticate/$', 'shopify_auth.views.authenticate'),
-  url(r'^$',              'shopify_auth.views.login'),
-)
+from . import views
+
+urlpatterns = [
+  url(r'^finalize/$',     views.finalize),
+  url(r'^authenticate/$', views.authenticate),
+  url(r'^$',              views.login),
+]


### PR DESCRIPTION
As of Django 1.9 the use of strings in URLs to specify the view function is deprecated.  I've replaced those by importing .views and passing the view functions directly.

Also, the use of patterns() is deprecated and unnecessary when there's no view prefix, so I've replaced that with a plain list.