### PR TITLE
Remove need for six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 django >=1.7
 ShopifyAPI >=2.1.5
-setuptools >=5.7
-six >=1.9.0

--- a/shopify_auth/decorators.py
+++ b/shopify_auth/decorators.py
@@ -1,4 +1,3 @@
-import six
 
 from functools import wraps
 
@@ -48,7 +47,7 @@ def login_required(f, redirect_field_name=REDIRECT_FIELD_NAME, login_url=None):
         # Extract the Shopify-specific authentication parameters from the current request.
         shopify_params = {
             k: v
-            for k, v in six.iteritems(request.GET)
+            for k, v in request.GET.iteritems()
             if k in {'shop', 'timestamp', 'signature', 'hmac'}
         }
 


### PR DESCRIPTION
The only use of six was calling iteritems on request.GET, which does that itself in its iteritems method.