### PR TITLE
Add `certifi` as requirement for Python 3.6 on MacOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django ==1.10.6
 ShopifyAPI >=2.1.5
-certifi==2017.1.23
+certifi==2017.1.23 # This needed when Mac OS runs python 3.x. Ref: https://bugs.python.org/issue28150

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-django ==1.10.6
+django >=1.7
 ShopifyAPI >=2.1.5
 certifi==2017.1.23 # This needed when Mac OS runs python 3.x. Ref: https://bugs.python.org/issue28150

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-django >=1.7
+django ==1.10.6
 ShopifyAPI >=2.1.5
+certifi==2017.1.23

--- a/shopify_auth/views.py
+++ b/shopify_auth/views.py
@@ -59,7 +59,7 @@ def finalize(request, *args, **kwargs):
     shop = request.POST.get('shop', request.GET.get('shop'))
 
     try:
-        shopify_session = shopify.Session(shop, token=kwargs.get('token'))
+        shopify_session = shopify.Session(shop)
         shopify_session.request_token(request.GET)
     except:
         login_url = reverse(login)

--- a/shopify_auth/views.py
+++ b/shopify_auth/views.py
@@ -59,7 +59,7 @@ def finalize(request, *args, **kwargs):
     shop = request.POST.get('shop', request.GET.get('shop'))
 
     try:
-        shopify_session = shopify.Session(shop)
+        shopify_session = shopify.Session(shop, token=kwargs.get('token'))
         shopify_session.request_token(request.GET)
     except:
         login_url = reverse(login)


### PR DESCRIPTION
Python 3.6 on MacOS uses an embedded version of OpenSSL, which does not use the system certificate store. Therefore, Mac OS users need to install `certifi`.

Ref: 
http://stackoverflow.com/questions/41691327/ssl-sslerror-ssl-certificate-verify-failed-certificate-verify-failed-ssl-c/41692664
https://bugs.python.org/issue28150

