### PR TITLE
Added request param to authentication for Django 1.11.3

### DIFF
--- a/shopify_auth/backends.py
+++ b/shopify_auth/backends.py
@@ -3,11 +3,11 @@ from django.contrib.auth.backends import RemoteUserBackend
 
 class ShopUserBackend(RemoteUserBackend):
 
-    def authenticate(self, myshopify_domain=None, token=None, **kwargs):
-        if not myshopify_domain or not token:
+    def authenticate(self, request=None, myshopify_domain=None, token=None, **kwargs):
+        if not myshopify_domain or not token or not request:
             return
 
-        user = super(ShopUserBackend, self).authenticate(remote_user=myshopify_domain)
+        user = super(ShopUserBackend, self).authenticate(request=request, remote_user=myshopify_domain)
         if not user:
             return
 

--- a/shopify_auth/views.py
+++ b/shopify_auth/views.py
@@ -66,7 +66,7 @@ def finalize(request, *args, **kwargs):
         return HttpResponseRedirect(login_url)
 
     # Attempt to authenticate the user and log them in.
-    user = auth.authenticate(myshopify_domain=shopify_session.url, token=shopify_session.token)
+    user = auth.authenticate(request=request, myshopify_domain=shopify_session.url, token=shopify_session.token)
     if user:
         auth.login(request, user)
 


### PR DESCRIPTION
Thanks for making this repo! I was testing this out in Django 1.11.3 and it was failing in ShopUserBackend when calling super(ShopUserBackend, self).authenticate(). It appears the request is now a required parameter. 