### PR TITLE
Remove deprecated versions of python and django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,28 +4,19 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy"
   - "pypy3"
 
 env:
-  - DJANGO="Django<1.8"
   - DJANGO="Django<1.9"
-  - DJANGO="Django<1.10"
   - DJANGO="Django<1.11"
+  - DJANGO="Django<2.0"
 
 matrix:
   exclude:
-    - env: DJANGO="Django<1.8"
-      python: "3.5"
-    - env: DJANGO="Django<1.10"
-      python: "3.3"
-    - env: DJANGO="Django<1.10"
-      python: "pypy3"
-    - env: DJANGO="Django<1.11"
-      python: "3.3"
     - env: DJANGO="Django<1.11"
       python: "pypy3"
 

--- a/shopify_auth/models.py
+++ b/shopify_auth/models.py
@@ -7,14 +7,14 @@ from django.utils.encoding import python_2_unicode_compatible
 
 class ShopUserManager(BaseUserManager):
 
-    def create_user(self, myshopify_domain, domain, password=None):
+    def create_user(self, myshopify_domain, password=None):
         """
-        Creates and saves a ShopUser with the given domains and password.
+        Creates and saves a ShopUser with the given domain and password.
         """
         if not myshopify_domain:
             raise ValueError('ShopUsers must have a myshopify domain')
 
-        user = self.model(myshopify_domain=myshopify_domain, domain=domain)
+        user = self.model(myshopify_domain=myshopify_domain)
 
         # Never want to be able to log on externally.
         # Authentication will be taken care of by Shopify OAuth.
@@ -22,11 +22,11 @@ class ShopUserManager(BaseUserManager):
         user.save(using=self._db)
         return user
 
-    def create_superuser(self, myshopify_domain, domain, password):
+    def create_superuser(self, myshopify_domain, password):
         """
         Creates and saves a ShopUser with the given domains and password.
         """
-        return self.create_user(myshopify_domain, domain, password)
+        return self.create_user(myshopify_domain, password)
 
 
 @python_2_unicode_compatible

--- a/shopify_auth/tests/test_user.py
+++ b/shopify_auth/tests/test_user.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-
+from django.contrib.auth.models import User
 
 class ViewsTestCase(TestCase):
 

--- a/shopify_auth/tests/test_user.py
+++ b/shopify_auth/tests/test_user.py
@@ -1,8 +1,19 @@
 from django.test import TestCase
-from django.contrib.auth.models import User
+from django.conf import settings
+from django.core.management import call_command
+
+from shopify_auth.models import AbstractShopUser
+
+
+class AuthAppShopUser(AbstractShopUser):
+    class Meta:
+        app_label = 'shopify_auth'
+
 
 class ViewsTestCase(TestCase):
 
+    def setUp(self):
+        settings.AUTH_USER_MODEL = 'shopify_auth.AuthAppShopUser'
+
     def test_create_super_user(self):
-        User.objects.create_superuser(username='admin', password='adminadmin', email='')
-        
+        call_command('createsuperuser', '--noinput',  myshopify_domain='myshop.shopify.com')

--- a/shopify_auth/tests/test_user.py
+++ b/shopify_auth/tests/test_user.py
@@ -1,0 +1,8 @@
+from django.test import TestCase
+
+
+class ViewsTestCase(TestCase):
+
+    def test_create_super_user(self):
+        User.objects.create_superuser(username='admin', password='adminadmin', email='')
+        


### PR DESCRIPTION
 https://www.python.org/downloads/release/python-337/
- python 3.3 is end of life
- add django 3.6 to the matrix

https://www.djangoproject.com/download/#supported-versions
- django 1.7 is end of life
- django 1.9 is end of life
- django 1.10 will be end of life in december 2017 (Keeping it for now)
- add django 1.11 to the matrix so that we can test the other pull requests against it


* Added a test for the super user (Should fail until #23 is merged)
