### PR TITLE
[WIP] Modify auth flow to support Safari 12

### DIFF
--- a/shopify_auth/decorators.py
+++ b/shopify_auth/decorators.py
@@ -56,6 +56,8 @@ def login_required(f, redirect_field_name=REDIRECT_FIELD_NAME, login_url=None):
         if is_authenticated(request.user):
             return f(request, *args, **kwargs)
 
+        request.session['shopify.cookies_persist'] = True
+
         # Extract the Shopify-specific authentication parameters from the current request.
         shopify_params = {
             k: request.GET[k]

--- a/shopify_auth/templates/shopify_auth/enable_cookies.html
+++ b/shopify_auth/templates/shopify_auth/enable_cookies.html
@@ -1,0 +1,423 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <style>
+    html,
+    body {
+      min-height:100%;
+      height:100%;
+      font-size:1.5rem;
+      font-weight:400;
+      line-height:2rem;
+      text-transform:initial;
+      letter-spacing:initial;
+      font-weight:400;
+      color:#212b36;
+      font-family:-apple-system, BlinkMacSystemFont, San Francisco, Roboto, Segoe UI, Helvetica Neue, sans-serif;
+    }
+
+    @media (min-width: 40em) {
+      html,
+      body {
+        font-size:1.4rem;
+      }
+    }
+
+    html {
+      position:relative;
+      font-size:62.5%;
+      -webkit-font-smoothing:antialiased;
+      -moz-osx-font-smoothing:grayscale;
+      -webkit-text-size-adjust:100%;
+      -ms-text-size-adjust:100%;
+      text-size-adjust:100%;
+      text-rendering:optimizeLegibility;
+    }
+
+    body {
+      min-height:100%;
+      margin:0;
+      padding:0;
+      background-color:#f4f6f8;
+    }
+
+    *,
+    *::before,
+    *::after{
+      box-sizing:border-box; }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p {
+      margin:0;
+      font-size:1em;
+      font-weight:400;
+    }
+
+    #CookiePartitionPrompt {
+      display: none;
+    }
+
+    .Polaris-Page {
+      margin:0 auto;
+      padding:0;
+      max-width:99.8rem;
+    }
+
+    @media (min-width: 30.625em) {
+      .Polaris-Page {
+        padding:0 2rem;
+      }
+    }
+    @media (min-width: 46.5em) {
+      .Polaris-Page {
+        padding:0 3.2rem;
+      }
+    }
+
+    .Polaris-Page__Content {
+      margin:2rem 0;
+    }
+
+    @media (min-width: 46.5em) {
+      .Polaris-Page__Content {
+        margin-top:2rem;
+      }
+    }
+
+    @media (min-width: 46.5em) {
+      .Polaris-Page {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+      }
+    }
+
+    .Polaris-Layout {
+      display:-webkit-box;
+      display:-ms-flexbox;
+      display:flex;
+      -ms-flex-wrap:wrap;
+      flex-wrap:wrap;
+      -webkit-box-pack:center;
+      -ms-flex-pack:center;
+      justify-content:center;
+      -webkit-box-align:start;
+      -ms-flex-align:start;
+      align-items:flex-start;
+      margin-top:-2rem;
+      margin-left:-2rem;
+    }
+
+    .Polaris-Layout__Section {
+      -webkit-box-flex:2;
+      -ms-flex:2 2 48rem;
+      flex:2 2 48rem;
+      min-width:51%;
+    }
+
+    .Polaris-Layout__Section--fullWidth {
+      -webkit-box-flex:1;
+      -ms-flex:1 1 100%;
+      flex:1 1 100%;
+    }
+
+    .Polaris-Layout__Section {
+      max-width:calc(100% - 2rem);
+      margin-top:2rem;
+      margin-left:2rem;
+    }
+
+    .Polaris-Stack {
+      margin-top:-1.6rem;
+      margin-left:-1.6rem;
+      display:-webkit-box;
+      display:-ms-flexbox;
+      display:flex;
+      -ms-flex-wrap:wrap;
+      flex-wrap:wrap;
+      -webkit-box-align:stretch;
+      -ms-flex-align:stretch;
+      align-items:stretch;
+    }
+
+    .Polaris-Stack > .Polaris-Stack__Item {
+      margin-top:1.6rem;
+      margin-left:1.6rem;
+      max-width:calc(100% - 1.6rem);
+    }
+
+    .Polaris-Stack__Item {
+      -webkit-box-flex:0;
+      -ms-flex:0 0 auto;
+      flex:0 0 auto;
+      min-width:0;
+    }
+
+    .Polaris-Heading {
+      font-size:1.7rem;
+      font-weight:600;
+      line-height:2.4rem;
+      margin:0;
+    }
+
+    @media (min-width: 40em) {
+      .Polaris-Heading {
+        font-size:1.6rem;
+      }
+    }
+
+    .Polaris-Card {
+      overflow:hidden;
+      background-color:white;
+      box-shadow:0 0 0 1px rgba(63, 63, 68, 0.05), 0 1px 3px 0 rgba(63, 63, 68, 0.15);
+    }
+
+    .Polaris-Card + .Polaris-Card {
+      margin-top:2rem;
+    }
+
+    @media (min-width: 30.625em) {
+      .Polaris-Card {
+        border-radius:3px;
+      }
+    }
+
+    .Polaris-Card__Header {
+      padding:2rem 2rem 0;
+    }
+
+    .Polaris-Card__Section {
+      padding:2rem;
+    }
+
+    .Polaris-Card__Section + .Polaris-Card__Section {
+      border-top:1px solid #dfe3e8;
+    }
+
+    .Polaris-Card__Section--subdued {
+      background-color:#f9fafb;
+    }
+
+
+    .Polaris-Stack--distributionTrailing {
+      -webkit-box-pack:end;
+      -ms-flex-pack:end;
+      justify-content:flex-end;
+    }
+
+    .Polaris-Stack--vertical {
+      -webkit-box-orient:vertical;
+      -webkit-box-direction:normal;
+      -ms-flex-direction:column;
+      flex-direction:column;
+    }
+
+    .Polaris-Button {
+      fill:#637381;
+      position:relative;
+      display:-webkit-inline-box;
+      display:-ms-inline-flexbox;
+      display:inline-flex;
+      -webkit-box-align:center;
+      -ms-flex-align:center;
+      align-items:center;
+      -webkit-box-pack:center;
+      -ms-flex-pack:center;
+      justify-content:center;
+      min-height:3.6rem;
+      min-width:3.6rem;
+      margin:0;
+      padding:0.7rem 1.6rem;
+      background:linear-gradient(to bottom, white, #f9fafb);
+      border:1px solid #c4cdd5;
+      box-shadow:0 1px 0 0 rgba(22, 29, 37, 0.05);
+      border-radius:3px;
+      line-height:1;
+      color:#212b36;
+      text-align:center;
+      cursor:pointer;
+      -webkit-user-select:none;
+      -moz-user-select:none;
+      -ms-user-select:none;
+      user-select:none;
+      text-decoration:none;
+      transition-property:background, border, box-shadow;
+      transition-duration:200ms;
+      transition-timing-function:cubic-bezier(0.64, 0, 0.35, 1);
+    }
+
+    .Polaris-Button:hover {
+      background:linear-gradient(to bottom, #f9fafb, #f4f6f8);
+      border-color:#c4cdd5;
+    }
+
+    .Polaris-Button:focus {
+      border-color:#5c6ac4;
+      outline:0;
+      box-shadow:0 0 0 1px #5c6ac4;
+    }
+
+    .Polaris-Button:active {
+      background:linear-gradient(to bottom, #f4f6f8, #f4f6f8);
+      border-color:#c4cdd5;
+      box-shadow:0 0 0 0 transparent, inset 0 1px 1px 0 rgba(99, 115, 129, 0.1), inset 0 1px 4px 0 rgba(99, 115, 129, 0.2);
+    }
+
+    .Polaris-Button.Polaris-Button--disabled {
+      fill:#919eab;
+      transition:none;
+      background:linear-gradient(to bottom, #f4f6f8, #f4f6f8);
+      color:#919eab;
+    }
+
+    .Polaris-Button__Content {
+      font-size:1.5rem;
+      font-weight:400;
+      line-height:1.6rem;
+      text-transform:initial;
+      letter-spacing:initial;
+      position:relative;
+      display:-webkit-box;
+      display:-ms-flexbox;
+      display:flex;
+      -webkit-box-pack:center;
+      -ms-flex-pack:center;
+      justify-content:center;
+      -webkit-box-align:center;
+      -ms-flex-align:center;
+      align-items:center;
+      min-width:1px;
+      min-height:1px;
+    }
+
+    @media (min-width: 40em) {
+      .Polaris-Button__Content {
+        font-size:1.4rem;
+      }
+    }
+
+    .Polaris-Button--primary {
+      background:linear-gradient(to bottom, #6371c7, #5563c1);
+      border-color:#3f4eae;
+      box-shadow:inset 0 1px 0 0 #6774c8, 0 1px 0 0 rgba(22, 29, 37, 0.05), 0 0 0 0 transparent;
+      color:white;
+      fill:white;
+    }
+
+    .Polaris-Button--primary:hover {
+      background:linear-gradient(to bottom, #5c6ac4, #4959bd);
+      border-color:#3f4eae;
+      color:white;
+      text-decoration:none;
+    }
+
+    .Polaris-Button--primary:focus {
+      border-color:#202e78;
+      box-shadow:inset 0 1px 0 0 #6f7bcb, 0 1px 0 0 rgba(22, 29, 37, 0.05), 0 0 0 1px #202e78;
+    }
+
+    .Polaris-Button--primary:active {
+      background:linear-gradient(to bottom, #3f4eae, #3f4eae);
+      border-color:#38469b;
+      box-shadow:inset 0 0 0 0 transparent, 0 1px 0 0 rgba(22, 29, 37, 0.05), 0 0 1px 0 #38469b;
+    }
+
+    .Polaris-Button--primary.Polaris-Button--disabled {
+      fill:white;
+      background:linear-gradient(to bottom, #bac0e6, #bac0e6);
+      border-color:#a7aedf;
+      box-shadow:none;
+      color:white;
+    }
+  </style>
+  <base target="_top">
+  <title>Redirecting…</title>
+
+  <script>
+    function setCookieAndRedirect() {
+      document.cookie = "shopify.cookies_persist=true;path=/";
+      window.location.href = "https://{{shop}}/admin/apps/{{SHOPIFY_APP_API_KEY}}";
+    }
+
+    function shouldDisplayPrompt() {
+      if (navigator.userAgent.indexOf('com.jadedpixel.pos') !== -1) {
+        return false;
+      }
+
+      if (navigator.userAgent.indexOf('Shopify Mobile/iOS') !== -1) {
+        return false;
+      }
+
+      return Boolean(document.hasStorageAccess);
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+      if (shouldDisplayPrompt()) {
+        var itpContent = document.querySelector('#CookiePartitionPrompt');
+        itpContent.style.display = 'block';
+
+        var button = document.querySelector('#AcceptCookies');
+        button.addEventListener('click', setCookieAndRedirect);
+      } else {
+        setCookieAndRedirect();
+      }
+    });
+  </script>
+</head>
+
+<body>
+  <main id="CookiePartitionPrompt">
+    <div class="Polaris-Page">
+      <div class="Polaris-Page__Content">
+        <div class="Polaris-Layout">
+          <div class="Polaris-Layout__Section">
+            <div class="Polaris-Stack Polaris-Stack--vertical">
+              <div class="Polaris-Stack__Item">
+                <div class="Polaris-Card">
+                  <div class="Polaris-Card__Header">
+                    <h1 class="Polaris-Heading">
+                      Enable cookies from {{SHOPIFY_APP_NAME}}
+                    </h1>
+                  </div>
+                  <div class="Polaris-Card__Section">
+                    <p>
+                      You must manually enable cookies in this browser in order to use {{SHOPIFY_APP_NAME}} within
+                      Shopify.
+                    </p>
+                  </div>
+                  <div class="Polaris-Card__Section Polaris-Card__Section--subdued">
+                    <p>
+                      Cookies let the app authenticate you by temporarily storing your preferences and personal
+                      information. They expire
+                      after 30 days.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div class="Polaris-Stack__Item">
+                <div class="Polaris-Stack Polaris-Stack--distributionTrailing">
+                  <div class="Polaris-Stack__Item">
+                    <button type="button" class="Polaris-Button Polaris-Button--primary" id="AcceptCookies">
+                      <span class="Polaris-Button__Content"><span>
+                          Enable cookies</span></span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+
+</html>

--- a/shopify_auth/tests/test_views.py
+++ b/shopify_auth/tests/test_views.py
@@ -28,8 +28,13 @@ class ViewsTestCase(TestCase):
         response = self.client.post('/authenticate/')
         self.assertEqual(response.status_code, 302)
 
+        session = self.client.session
+        session['shopify.top_level_oauth'] = True
+        session['shopify.cookies_persist'] = True
+        session.save()
+
         response = self.client.get('/?shop=test.myshopify.com')
-        self.assertContains(response, 'window.top.location.href = "https://test.myshopify.com/admin/oauth/authorize')
+        self.assertRedirects(response, 'https://test.myshopify.com/admin/oauth/authorize?client_id=test-api-key&scope=read_products&redirect_uri=http%3A%2F%2Ftestserver%2Ffinalize%2F', fetch_redirect_response=False)
 
         # Dev mode so token does not need to be valid
         settings.SHOPIFY_APP_DEV_MODE = True
@@ -38,5 +43,3 @@ class ViewsTestCase(TestCase):
         self.assertGreater(int(self.client.session['_auth_user_id']), 0)
         self.assertEqual(self.client.session['_auth_user_backend'], 'shopify_auth.backends.ShopUserBackend')
         self.assertIsNot(self.client.session['_auth_user_hash'], None)
-
-

--- a/shopify_auth/urls.py
+++ b/shopify_auth/urls.py
@@ -3,7 +3,8 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-  url(r'^finalize/$',     views.finalize),
-  url(r'^authenticate/$', views.authenticate),
-  url(r'^$',              views.login),
+  url(r'^finalize/$',        views.finalize),
+  url(r'^authenticate/$',    views.authenticate),
+  url(r'^enable_cookies/$',  views.enable_cookies),
+  url(r'^$',                 views.login),
 ]


### PR DESCRIPTION
Over the weekend I sort of solved login issue caused by [Intelligent Tracking Prevention introduced in Safari 12](https://help.shopify.com/en/api/guides/itp-impact). 

I tried to follow both https://github.com/Shopify/shopify_app/pull/617 and https://github.com/Shopify/quilt/pull/268.  I got it somewhat working as you can see on https://shopify-heureka.herokuapp.com/ But I feel like I'm missing something. @ragalie, could you please take a look as you have quite experience in this field ;)