### PR TITLE
Added instruction to migrate the AuthAppShopUser model.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ class AuthAppShopUser(AbstractShopUser):
     pass
 ```
 
-Before moving forward, ensure this model has been added to the database by running `python manage.py migrate`.
+Before moving forward, ensure this model has been added to the database by running
+```
+python manage.py makemigrations
+python manage.py migrate
+```
 
 Then make sure that you have the following line or similar in `settings.py`:
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ class AuthAppShopUser(AbstractShopUser):
     pass
 ```
 
+Before moving forward, ensure this model has been added to the database by running `python manage.py migrate`.
+
 Then make sure that you have the following line or similar in `settings.py`:
 
 ```python


### PR DESCRIPTION
I followed the instructions and forgot to migrate the database after adding the `AuthAppShopUser` model. When I eventually ran the migrations, I got the following error:
```
The field admin.LogEntry.user was declared with a lazy reference to 'auth_app.authappshopuser', but app 'auth_app' doesn't provide model 'authappshopuser'.
```

Migrating the database first, solved this issue which is why I think this should be added to the README.