### PR TITLE
Migrate redirect calls to App Bridge

### DIFF
--- a/shopify_auth/templates/shopify_auth/iframe_redirect.html
+++ b/shopify_auth/templates/shopify_auth/iframe_redirect.html
@@ -1,17 +1,16 @@
 <script type="text/javascript">
-  // If the current window is the 'parent', change the URL by setting location.href
-  if (window.top == window.self) {
-    window.top.location.href = "{{ redirect_uri }}";
-
-  // If the current window is the 'child', change the parent's URL with postMessage
-  } else {
-    var normalizedLink = document.createElement('a');
-    normalizedLink.href = "{{ redirect_uri }}";
-
-    var message = JSON.stringify({
-      message: "Shopify.API.remoteRedirect",
-      data: { location: normalizedLink.href }
+    const AppBridge = window['app-bridge'];
+    const createApp = AppBridge.default;
+    const Redirect = AppBridge.actions.Redirect;
+    const app = createApp({
+        apiKey: window.apiKey,
+        shopOrigin: '{{ shop }}',
     });
-    window.parent.postMessage(message, "https://{{ shop }}");
-  }
+
+    const normalizedLink = document.createElement('a');
+    normalizedLink.href = '{{ redirect_uri }}';
+
+    Redirect.create(app).dispatch(Redirect.Action.REMOTE, normalizedLink.href);
+
+    window.appBridgeRedirect = appBridgeRedirect;
 </script>

--- a/shopify_auth/templates/shopify_auth/iframe_redirect.html
+++ b/shopify_auth/templates/shopify_auth/iframe_redirect.html
@@ -1,15 +1,15 @@
+<script src="https://unpkg.com/@shopify/app-bridge@2"></script>
 <script type="text/javascript">
     const AppBridge = window['app-bridge'];
-    const createApp = AppBridge.default;
-    const Redirect = AppBridge.actions.Redirect;
-    const app = createApp({
-        apiKey: window.apiKey,
-        shopOrigin: '{{ shop }}',
+    const app = AppBridge.default({
+        apiKey: "{{ SHOPIFY_APP_API_KEY }}",
+        shopOrigin: "{{ shop }}",
     });
 
     const normalizedLink = document.createElement('a');
-    normalizedLink.href = '{{ redirect_uri }}';
+    normalizedLink.href = "{{ redirect_uri }}";
 
+    const Redirect = AppBridge.actions.Redirect;
     Redirect.create(app).dispatch(Redirect.Action.REMOTE, normalizedLink.href);
 
     window.appBridgeRedirect = appBridgeRedirect;

--- a/shopify_auth/templates/shopify_auth/iframe_redirect.html
+++ b/shopify_auth/templates/shopify_auth/iframe_redirect.html
@@ -1,16 +1,22 @@
 <script src="https://unpkg.com/@shopify/app-bridge@2"></script>
 <script type="text/javascript">
-    const AppBridge = window['app-bridge'];
-    const app = AppBridge.default({
-        apiKey: "{{ SHOPIFY_APP_API_KEY }}",
-        shopOrigin: "{{ shop }}",
-    });
+    if (window.top === window.self) {
+        // If the current window is the 'parent', change the URL by setting location.href
+        window.top.location.href = "{{ redirect_uri }}";
+    } else {
+        // If the current window is the 'child', change the parent's URL with App Bridge Redirect
+        var AppBridge = window['app-bridge'];
+        var app = AppBridge.default({
+            apiKey: "{{ SHOPIFY_APP_API_KEY }}",
+            shopOrigin: "{{ shop }}",
+        });
 
-    const normalizedLink = document.createElement('a');
-    normalizedLink.href = "{{ redirect_uri }}";
+        var normalizedLink = document.createElement('a');
+        normalizedLink.href = "{{ redirect_uri }}";
 
-    const Redirect = AppBridge.actions.Redirect;
-    Redirect.create(app).dispatch(Redirect.Action.REMOTE, normalizedLink.href);
+        var Redirect = AppBridge.actions.Redirect;
+        Redirect.create(app).dispatch(Redirect.Action.REMOTE, normalizedLink.href);
 
-    window.appBridgeRedirect = appBridgeRedirect;
+        window.appBridgeRedirect = appBridgeRedirect;
+    }
 </script>

--- a/shopify_auth/templates/shopify_auth/iframe_redirect.html
+++ b/shopify_auth/templates/shopify_auth/iframe_redirect.html
@@ -1,10 +1,11 @@
 <script src="https://unpkg.com/@shopify/app-bridge@2"></script>
 <script type="text/javascript">
+    // If the current window is the 'parent', change the URL by setting location.href
     if (window.top === window.self) {
-        // If the current window is the 'parent', change the URL by setting location.href
         window.top.location.href = "{{ redirect_uri }}";
+
+    // If the current window is the 'child', change the parent's URL with App Bridge Redirect
     } else {
-        // If the current window is the 'child', change the parent's URL with App Bridge Redirect
         var AppBridge = window['app-bridge'];
         var app = AppBridge.default({
             apiKey: "{{ SHOPIFY_APP_API_KEY }}",

--- a/shopify_auth/templates/shopify_auth/iframe_redirect.html
+++ b/shopify_auth/templates/shopify_auth/iframe_redirect.html
@@ -17,7 +17,5 @@
 
         var Redirect = AppBridge.actions.Redirect;
         Redirect.create(app).dispatch(Redirect.Action.REMOTE, normalizedLink.href);
-
-        window.appBridgeRedirect = appBridgeRedirect;
     }
 </script>


### PR DESCRIPTION
Avoid making calls to the deprecated Embedded App SDK.

based on https://github.com/Shopify/shopify_app/pull/915/files

- [x] add `appBridge` script
- [x] if the current window is the 'child', change the parent's URL with App Bridge Redirect