### PR TITLE
admin.shopify.com related updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 - Removed support for cookie based embedded apps.
+### Changed
+- Migrate redirect calls to App Bridge 3.
+- The template `iframe_redirect.html` now expects `host` parameter, not `shop`.
+- `session_tokens.views.get_scope_permission` now detects `embedded` query parameter.
+- `session_tokens.views.FinalizeAuthView` now redirects to the domain defined in `host` query parameter if present.
+
 
 ## 1.2.3 - 2022-04-14
 

--- a/shopify_auth/session_tokens/tests/test_finalize_view.py
+++ b/shopify_auth/session_tokens/tests/test_finalize_view.py
@@ -6,6 +6,8 @@ from shopify_auth.tests.test_user import ViewsTestCase
 from django.contrib.auth import get_user_model
 import shopify
 
+HOST_MYSHOPIFY_DOMAIN = "cmFuZG9tX3Nob3AubXlzaG9waWZ5LmNvbS9hZG1pbg"
+HOST_ADMIN_SHOPIFY_COM = "YWRtaW4uc2hvcGlmeS5jb20vc3RvcmUvam9zZWYtZGV2LTIwMjEtMDc"
 
 def request_token(self, params):
     self.token = "TOKEN"
@@ -18,7 +20,7 @@ class FinalizeViewTest(ViewsTestCase):
         mck = self.shop_patcher.start()
         mck.current().currency = "CZK"
         self.addCleanup(self.shop_patcher.stop)
-        self.url = reverse("session_tokens:finalize") + "?shop=random_shop"
+        self.url = reverse("session_tokens:finalize") + "?shop=random_shop.myshopify.com"
 
     @patch.object(shopify.Session, "request_token", request_token)
     def test_creates_user(self):
@@ -30,3 +32,30 @@ class FinalizeViewTest(ViewsTestCase):
             ).exists()
         )
         self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "https://random_shop.myshopify.com/admin/apps/test-api-key")
+
+
+    @patch.object(shopify.Session, "request_token", request_token)
+    def test_creates_user_redirects_host_myshopify(self):
+        response = self.client.get(f"{self.url}&host={HOST_MYSHOPIFY_DOMAIN}")
+        AuthAppShopUser = get_user_model()
+        self.assertTrue(
+            AuthAppShopUser.objects.filter(
+                myshopify_domain="random_shop.myshopify.com"
+            ).exists()
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "https://random_shop.myshopify.com/admin/apps/test-api-key")
+
+
+    @patch.object(shopify.Session, "request_token", request_token)
+    def test_creates_user_redirects_host_admin_shopify_com(self):
+        response = self.client.get(f"{self.url}&host={HOST_ADMIN_SHOPIFY_COM}")
+        AuthAppShopUser = get_user_model()
+        self.assertTrue(
+            AuthAppShopUser.objects.filter(
+                myshopify_domain="random_shop.myshopify.com"
+            ).exists()
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "https://admin.shopify.com/store/josef-dev-2021-07/apps/test-api-key")

--- a/shopify_auth/session_tokens/tests/test_get_scope_permission.py
+++ b/shopify_auth/session_tokens/tests/test_get_scope_permission.py
@@ -6,12 +6,23 @@ from shopify_auth.session_tokens.views import get_scope_permission
 
 
 class GetScopePermissionTest(TestCase):
-    def test_get_scope_permission(self):
+    def test_get_scope_permission_not_embedded(self):
         self.client = Client()
         rf = RequestFactory()
         self.myshopify_domain = "test-1.myshopify.com"
         shop = get_user_model().objects.create(myshopify_domain=self.myshopify_domain)
         request = rf.get(f"/?shop={shop.myshopify_domain}")
+        request.user = shop
+        response = get_scope_permission(request, shop.myshopify_domain)
+        self.assertRedirects(response, "https://test-1.myshopify.com/admin/oauth/authorize?client_id=test-api-key&redirect_uri=http%3A%2F%2Ftestserver%2Fsession_tokens%2Ffinalize&scope=read_products", fetch_redirect_response=False)
+
+
+    def test_get_scope_permission_embedded(self):
+        self.client = Client()
+        rf = RequestFactory()
+        self.myshopify_domain = "test-1.myshopify.com"
+        shop = get_user_model().objects.create(myshopify_domain=self.myshopify_domain)
+        request = rf.get(f"/?shop={shop.myshopify_domain}&embedded=1&host=placeholder")
         request.user = shop
         response = get_scope_permission(request, shop.myshopify_domain)
         self.assertEqual(response.status_code, 200)

--- a/shopify_auth/session_tokens/views.py
+++ b/shopify_auth/session_tokens/views.py
@@ -34,7 +34,7 @@ def get_scope_permission(request, myshopify_domain):
 
     host = request.GET.get("host")
     if not host:
-        return HttpResponse("expected host query parameter when embedded=1 is present")
+        raise Exception("expected host query parameter when embedded=1 is present")
 
     return render(
         request,

--- a/shopify_auth/templates/shopify_auth/iframe_redirect.html
+++ b/shopify_auth/templates/shopify_auth/iframe_redirect.html
@@ -1,21 +1,44 @@
-<script src="https://unpkg.com/@shopify/app-bridge@2"></script>
+<script src="https://unpkg.com/@shopify/app-bridge@3"></script>
+<script src="https://unpkg.com/@shopify/app-bridge-utils@3"></script>
 <script type="text/javascript">
-    // If the current window is the 'parent', change the URL by setting location.href
-    if (window.top === window.self) {
-        window.top.location.href = "{{ redirect_uri|safe }}";
+    (function (window) {
+        function appBridgeRedirect(url) {
+            var AppBridge = window['app-bridge'];
+            var createApp = AppBridge.default;
+            var Redirect = AppBridge.actions.Redirect;
+            var shopifyData = document.body.dataset;
 
-    // If the current window is the 'child', change the parent's URL with App Bridge Redirect
-    } else {
-        var AppBridge = window['app-bridge'];
-        var app = AppBridge.default({
-            apiKey: "{{ SHOPIFY_APP_API_KEY }}",
-            shopOrigin: "{{ shop }}",
-        });
+            var app = createApp({
+                apiKey: '{{ SHOPIFY_APP_API_KEY }}',
+                host: '{{ host }}',
+            });
 
-        var normalizedLink = document.createElement('a');
-        normalizedLink.href = "{{ redirect_uri|safe }}";
+            var normalizedLink = document.createElement('a');
+            normalizedLink.href = url;
 
-        var Redirect = AppBridge.actions.Redirect;
-        Redirect.create(app).dispatch(Redirect.Action.REMOTE, normalizedLink.href);
-    }
+            Redirect.create(app).dispatch(Redirect.Action.REMOTE, normalizedLink.href);
+        }
+
+        window.appBridgeRedirect = appBridgeRedirect;
+    })(window);
+
+    (function () {
+        function redirect() {
+            var appBridgeUtils = window['app-bridge-utils'];
+            var targetUrl = '{{ redirect_uri|safe }}';
+
+            if (appBridgeUtils.isShopifyEmbedded()) {
+                window.appBridgeRedirect(targetUrl);
+            } else {
+                window.top.location.href = targetUrl;
+            }
+        }
+
+        document.addEventListener("DOMContentLoaded", redirect);
+
+        // In the turbolinks context, neither DOMContentLoaded nor turbolinks:load
+        // consistently fires. This ensures that we at least attempt to fire in the
+        // turbolinks situation as well.
+        redirect();
+    })();
 </script>


### PR DESCRIPTION
Changes based on https://shopify.dev/apps/tools/app-bridge/updating-overview

- Migrate redirect calls to App Bridge 3.
- The template `iframe_redirect.html` now expects `host` parameter, not `shop`.
- `session_tokens.views.get_scope_permission` now detects `embedded` query parameter.
- `session_tokens.views.FinalizeAuthView` now redirects to the domain defined in `host` query parameter if present.
